### PR TITLE
enable replication privileges on bind

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -559,6 +559,9 @@ func (b *RDSBroker) Bind(
 		if err := decoder.Decode(&bindParameters); err != nil {
 			return bindingResponse, err
 		}
+		if err := bindParameters.Validate(); err != nil {
+			return bindingResponse, err
+		}
 	}
 
 	_, ok := b.catalog.FindService(details.ServiceID)
@@ -598,7 +601,7 @@ func (b *RDSBroker) Bind(
 	}
 	defer sqlEngine.Close()
 
-	dbUsername, dbPassword, err := sqlEngine.CreateUser(bindingID, dbName)
+	dbUsername, dbPassword, err := sqlEngine.CreateUser(bindingID, dbName, bindParameters.GrantReplication)
 	if err != nil {
 		return bindingResponse, err
 	}

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -27,8 +27,7 @@ type UpdateParameters struct {
 }
 
 type BindParameters struct {
-	// This is currently empty, but preserved to make it easier to add
-	// bind-time parameters in future.
+	GrantReplication	bool	`json:"grant_replication"`
 }
 
 func (pp *ProvisionParameters) Validate() error {
@@ -56,5 +55,9 @@ func (up *UpdateParameters) CheckForCompatibilityWithPlanChange() error {
 	if len(up.DisableExtensions) > 0 {
 		return fmt.Errorf("Invalid to disable extensions and update plan in the same command")
 	}
+	return nil
+}
+
+func (bp *BindParameters) Validate() error {
 	return nil
 }

--- a/sqlengine/mysql_engine.go
+++ b/sqlengine/mysql_engine.go
@@ -62,7 +62,7 @@ func (d *MySQLEngine) Close() {
 	}
 }
 
-func (d *MySQLEngine) CreateUser(bindingID, dbname string) (username, password string, err error) {
+func (d *MySQLEngine) CreateUser(bindingID, dbname string, grantReplication bool) (username, password string, err error) {
 	username = d.UsernameGenerator(bindingID)
 	password = generatePassword()
 	options := []string{

--- a/sqlengine/mysql_engine_test.go
+++ b/sqlengine/mysql_engine_test.go
@@ -107,7 +107,7 @@ var _ = Describe("MySQLEngine", func() {
 		})
 
 		It("CreateUser() should successfully complete it's destiny", func() {
-			createdUser, createdPassword, err := mysqlEngine.CreateUser(bindingID, dbname)
+			createdUser, createdPassword, err := mysqlEngine.CreateUser(bindingID, dbname, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(createdUser).NotTo(BeEmpty())
 			Expect(createdPassword).NotTo(BeEmpty())
@@ -126,7 +126,7 @@ var _ = Describe("MySQLEngine", func() {
 		It("DropUser() should drop the username generated the old way successfully", func() {
 			mysqlEngine.UsernameGenerator = generateUsernameOld
 
-			_, _, err := mysqlEngine.CreateUser(bindingID, dbname)
+			_, _, err := mysqlEngine.CreateUser(bindingID, dbname, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			mysqlEngine.UsernameGenerator = generateUsername

--- a/sqlengine/sql_engine.go
+++ b/sqlengine/sql_engine.go
@@ -15,7 +15,7 @@ const (
 type SQLEngine interface {
 	Open(address string, port int64, dbname string, username string, password string) error
 	Close()
-	CreateUser(bindingID, dbname string) (string, string, error)
+	CreateUser(bindingID, dbname string, grantReplication bool) (string, string, error)
 	DropUser(bindingID string) error
 	ResetState() error
 	URI(address string, port int64, dbname string, username string, password string) string


### PR DESCRIPTION
### Context
We need a way to create logical replication slots and some associated resources (schema, table, function). Doing this requires special permissions in Postgres (`REPLICATION`) that the basic user provisioned for binding applications does not have. Additionally, in an RDS context, AWS manages some roles that need to be used instead of what one might do on a different Postgres instance (see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html).

### Summary
This change enables a bind parameter (`grant_replication`) that when set to `true` grants the binding user the necessary permissions to create replication slots (`rds_replication`). It is used like this:

```
cf bind-service my-app my-db  -c '{"grant_replication": true }'
```
(or can be set via manifest.yml).

This is only implemented for Postgres, and does not come with the inverse revoke function. The binding can be removed and another one created if the raised permissions are a concern.

The other caveat here is that the parameter group `rds.logical_replication` defaults to `0` but must be enabled by setting to `1`. The RDS instance must be rebooted for this to take effect.
