### PR TITLE
Support dynamic sizing of RDS instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Provision calls support the following optional [arbitrary parameters](https://do
 | `preferred_maintenance_window` | String   | The weekly time range during which system maintenance can occur (*)
 | `replica_source_db_arn`        | String   | An ARN for an existing RDS instance that you would like to use as a source for a Read Replica instance
 | `enable_extensions`           | []String | The names of the extensions which should be enabled. Supported extensions are specified by the plan, and the supplied list is combined with the set of default extensions defined by the plan. If this parameter isn't provided, the plan's default extensions will be enabled. (*\*)
+| `max_allocated_storage`        | Integer | The maximum amount of storage (in Gb) allowed for this RDS instance. If provided and larger than the amount of allocated storage defined by the service plan, then storage autoscaling will be enabled.
 
 (\*) Refer to the [Amazon Relational Database Service Documentation](https://aws.amazon.com/documentation/rds/) for more details about how to set these properties
 
@@ -80,6 +81,7 @@ Update calls support the following optional [arbitrary parameters](https://docs.
 | `force_failover`               | Boolean | For HA failover during reboot. Only valid when used with `reboot` and for HA plans. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html for detais.
 | `enable_extensions`           | []String | The names of the extensions which should be enabled. Supported extensions are specified by the plan, and the supplied list is combined with the set of default extensions defined by the plan. (*\*)
 | `disable_extensions`           | []String | The names of the extensions which should be disabled. Supported extensions are specified by the plan, and default extensions cannot be disabled. (*\*)
+| `max_allocated_storage`        | Integer | The maximum amount of storage (in Gb) allowed for this RDS instance. If provided and larger than the amount of allocated storage already configured for this instance, then storage autoscaling will be enabled. Note: if the instance has already been scaled up from the service plan, you will need to provide the currently allocated storage amount to disable autoscaling.
 
 (*) Refer to the [Amazon Relational Database Service Documentation](https://aws.amazon.com/documentation/rds/) for more details about how to set these properties
 

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -1167,6 +1167,9 @@ func (b *RDSBroker) newCreateDBInstanceInput(instanceID string, servicePlan Serv
 	if provisionParameters.PreferredMaintenanceWindow != "" {
 		createDBInstanceInput.PreferredMaintenanceWindow = aws.String(provisionParameters.PreferredMaintenanceWindow)
 	}
+	if provisionParameters.MaxAllocatedStorage != 0 && provisionParameters.MaxAllocatedStorage > *servicePlan.RDSProperties.AllocatedStorage {
+		createDBInstanceInput.MaxAllocatedStorage = aws.Int64(provisionParameters.MaxAllocatedStorage)
+	}
 	return createDBInstanceInput, nil
 }
 
@@ -1291,6 +1294,9 @@ func (b *RDSBroker) newModifyDBInstanceInput(instanceID string, servicePlan Serv
 	}
 	if updateParameters.PreferredMaintenanceWindow != "" {
 		modifyDBInstanceInput.PreferredMaintenanceWindow = aws.String(updateParameters.PreferredMaintenanceWindow)
+	}
+	if updateParameters.MaxAllocatedStorage != 0 {
+		modifyDBInstanceInput.MaxAllocatedStorage = aws.Int64(updateParameters.MaxAllocatedStorage)
 	}
 
 	b.logger.Debug("newModifyDBInstanceInputAndTags", lager.Data{

--- a/rdsbroker/catalog.go
+++ b/rdsbroker/catalog.go
@@ -59,6 +59,7 @@ type RDSProperties struct {
 	DBSecurityGroups           []*string `json:"db_security_groups,omitempty"`
 	DBSubnetGroupName          *string   `json:"db_subnet_group_name,omitempty"`
 	LicenseModel               *string   `json:"license_model,omitempty"`
+	MaxAllocatedStorage        *int64    `json:"max_allocated_storage,omitempty"`
 	MultiAZ                    *bool     `json:"multi_az,omitempty"`
 	OptionGroupName            *string   `json:"option_group_name,omitempty"`
 	Port                       *int64    `json:"port,omitempty"`

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -13,6 +13,7 @@ type ProvisionParameters struct {
 	RestoreFromLatestSnapshotOf     *string  `json:"restore_from_latest_snapshot_of"`
 	RestoreFromLatestSnapshotBefore *string  `json:"restore_from_latest_snapshot_before"`
 	Extensions                      []string `json:"enable_extensions"`
+	MaxAllocatedStorage             int64    `json:"max_allocated_storage"`
 }
 
 type UpdateParameters struct {
@@ -25,6 +26,7 @@ type UpdateParameters struct {
 	ForceFailover              *bool    `json:"force_failover"`
 	EnableExtensions           []string `json:"enable_extensions"`
 	DisableExtensions          []string `json:"disable_extensions"`
+	MaxAllocatedStorage        int64    `json:"max_allocated_storage"`
 }
 
 type BindParameters struct {


### PR DESCRIPTION
## Context
RDS instances are currently provisioned with a static amount of allocated storage determined by the plan.

## Changes
This PR includes a new parameter `MaxAllocatedStorage` that can be passed during provision or as an update, which will set the max storage allowed for the RDS instance. More detail on the RDS docs: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html

This also includes support for this parameter at the plan level if we ever wanted to write plans with autoscaling predefined.

## Validation
- Added tests to validate the broker is respecting this parameter.
- I spun up RDS instances with and without autoscaling - and modified them; in all cases the instances reflected the changes in the AWS RDS console appropriately.