### PR TITLE
Upgrade to go 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-rds-broker
 
-go 1.13
+go 1.15
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,10 @@
 # code.cloudfoundry.org/lager v2.0.0+incompatible
+## explicit
 code.cloudfoundry.org/lager
 code.cloudfoundry.org/lager/lagerctx
 code.cloudfoundry.org/lager/lagertest
 # github.com/aws/aws-sdk-go v1.34.10
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
@@ -42,11 +44,16 @@ github.com/aws/aws-sdk-go/service/ec2
 github.com/aws/aws-sdk-go/service/rds
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
+# github.com/drewolson/testflight v1.0.0
+## explicit
 # github.com/go-sql-driver/mysql v1.5.0
+## explicit
 github.com/go-sql-driver/mysql
 # github.com/google/uuid v1.1.1
+## explicit
 github.com/google/uuid
 # github.com/gorilla/mux v1.7.3
+## explicit
 github.com/gorilla/mux
 # github.com/hpcloud/tail v1.0.0
 github.com/hpcloud/tail
@@ -57,9 +64,11 @@ github.com/hpcloud/tail/winfile
 # github.com/jmespath/go-jmespath v0.3.0
 github.com/jmespath/go-jmespath
 # github.com/lib/pq v0.0.0-20151007185736-ffe986aba3e6
+## explicit
 github.com/lib/pq
 github.com/lib/pq/oid
 # github.com/onsi/ginkgo v1.12.0
+## explicit
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
@@ -79,6 +88,7 @@ github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
 # github.com/onsi/gomega v1.9.0
+## explicit
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/gbytes
@@ -94,10 +104,13 @@ github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
 # github.com/pborman/uuid v1.2.0
+## explicit
 github.com/pborman/uuid
 # github.com/phayes/freeport v0.0.0-20141201041908-e7681b376149
+## explicit
 github.com/phayes/freeport
 # github.com/pivotal-cf/brokerapi v6.4.2+incompatible
+## explicit
 github.com/pivotal-cf/brokerapi
 github.com/pivotal-cf/brokerapi/auth
 github.com/pivotal-cf/brokerapi/domain
@@ -108,14 +121,17 @@ github.com/pivotal-cf/brokerapi/utils
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/robfig/cron v1.0.1-0.20171101201047-2315d5715e36
+## explicit
 github.com/robfig/cron
 # github.com/satori/go.uuid v1.1.1-0.20160927100844-b061729afc07
+## explicit
 github.com/satori/go.uuid
 # golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 golang.org/x/net/html
 golang.org/x/net/html/atom
 golang.org/x/net/html/charset
 # golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
+## explicit
 golang.org/x/sys/unix
 # golang.org/x/text v0.3.0
 golang.org/x/text/encoding


### PR DESCRIPTION
Upgrades to Go 1.15 since 1.13 is deprecated in the CF `go-buildpack`