### PR TITLE
Allow promotion of Read Replica instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*.coverprofile
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ unit: test_unit test_all_sql
 
 .PHONY: test_unit
 test_unit:
-	ginkgo -r --skipPackage=ci,sqlengine
+	ginkgo -cover -r --skipPackage=ci,sqlengine
 .PHONY: test_all_sql
 test_all_sql: test_postgres test_mysql
 .PHONY: test_postgres

--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -23,6 +23,7 @@ type RDSInstance interface {
 	DeleteSnapshots(brokerName string, keepForDays int) error
 	Create(createDBInstanceInput *rds.CreateDBInstanceInput) error
 	CreateReadReplica(createDBInstanceInput *rds.CreateDBInstanceReadReplicaInput) error
+	PromoteReadReplica(promoteReadReplicaInput *rds.PromoteReadReplicaInput) (*rds.DBInstance, error)
 	Restore(restoreRBInstanceInput *rds.RestoreDBInstanceFromDBSnapshotInput) error
 	Modify(modifyDBInstanceInput *rds.ModifyDBInstanceInput) (*rds.DBInstance, error)
 	AddTagsToResource(resourceArn string, tags []*rds.Tag) error

--- a/awsrds/fakes/fake_rds_instance.go
+++ b/awsrds/fakes/fake_rds_instance.go
@@ -32,9 +32,9 @@ type FakeRDSInstance struct {
 	createReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CreateReadReplicaStub           func(*rds.CreateDBInstanceReadReplicaInput) error
+	CreateReadReplicaStub        func(*rds.CreateDBInstanceReadReplicaInput) error
 	createReadReplicaMutex       sync.RWMutex
-	createReadReplicaArgsForCall    []struct {
+	createReadReplicaArgsForCall []struct {
 		arg1 *rds.CreateDBInstanceReadReplicaInput
 	}
 	createReadReplicaReturns struct {
@@ -184,6 +184,21 @@ type FakeRDSInstance struct {
 	modifyParameterGroupReturnsOnCall map[int]struct {
 		result1 error
 	}
+
+	PromoteReadReplicaStub        func(*rds.PromoteReadReplicaInput) (*rds.DBInstance, error)
+	promoteReadReplicaMutex       sync.RWMutex
+	promoteReadReplicaArgsForCall []struct {
+		promoteReadReplicaInput *rds.PromoteReadReplicaInput
+	}
+	promoteReadReplicaReturns struct {
+		result1 *rds.DBInstance
+		result2 error
+	}
+	promoteReadReplicaReturnsOnCall map[int]struct {
+		result1 *rds.DBInstance
+		result2 error
+	}
+
 	RebootStub        func(*rds.RebootDBInstanceInput) error
 	rebootMutex       sync.RWMutex
 	rebootArgsForCall []struct {
@@ -406,6 +421,63 @@ func (fake *FakeRDSInstance) CreateReadReplicaReturnsOnCall(i int, result1 error
 	fake.createReadReplicaReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeRDSInstance) PromoteReadReplica(promoteReadReplicaInput *rds.PromoteReadReplicaInput) (*rds.DBInstance, error) {
+	fake.promoteReadReplicaMutex.Lock()
+
+	ret, specificReturn := fake.promoteReadReplicaReturnsOnCall[len(fake.promoteReadReplicaArgsForCall)]
+
+	fake.promoteReadReplicaArgsForCall = append(fake.promoteReadReplicaArgsForCall, struct {
+		promoteReadReplicaInput *rds.PromoteReadReplicaInput
+	}{promoteReadReplicaInput})
+
+	fake.recordInvocation("PromoteReadReplica", []interface{}{promoteReadReplicaInput})
+
+	fake.promoteReadReplicaMutex.Unlock()
+
+	if fake.PromoteReadReplicaStub != nil {
+		return fake.PromoteReadReplicaStub(promoteReadReplicaInput)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.promoteReadReplicaReturns
+	return fakeReturns.result1, fakeReturns.result2
+	return nil, nil
+}
+
+func (fake *FakeRDSInstance) PromoteReadReplicaCallCount() int {
+	fake.promoteReadReplicaMutex.RLock()
+	defer fake.promoteReadReplicaMutex.RUnlock()
+	return len(fake.promoteReadReplicaArgsForCall)
+}
+
+func (fake *FakeRDSInstance) PromoteReadReplicaReturns(result1 *rds.DBInstance, result2 error) {
+	fake.promoteReadReplicaMutex.Lock()
+	defer fake.promoteReadReplicaMutex.Unlock()
+	fake.PromoteReadReplicaStub = nil
+	fake.promoteReadReplicaReturns = struct {
+		result1 *rds.DBInstance
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRDSInstance) PromoteReadReplicaReturnsOnCall(i int, result1 *rds.DBInstance, result2 error) {
+	fake.promoteReadReplicaMutex.Lock()
+	defer fake.promoteReadReplicaMutex.Unlock()
+
+	fake.PromoteReadReplicaStub = nil
+	if fake.promoteReadReplicaReturnsOnCall == nil {
+		fake.promoteReadReplicaReturnsOnCall = make(map[int]struct {
+			result1 *rds.DBInstance
+			result2 error
+		})
+	}
+	fake.promoteReadReplicaReturnsOnCall[i] = struct {
+		result1 *rds.DBInstance
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeRDSInstance) CreateParameterGroup(arg1 *rds.CreateDBParameterGroupInput) error {

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -251,6 +251,19 @@ func (r *RDSDBInstance) CreateReadReplica(createDBInstanceInput *rds.CreateDBIns
 	return nil
 }
 
+func (r *RDSDBInstance) PromoteReadReplica(promoteReadReplicaInput *rds.PromoteReadReplicaInput) (*rds.DBInstance, error) {
+	sanitizedDBInstanceInput := *promoteReadReplicaInput
+	r.logger.Debug("promote-db-instance-read-replica", lager.Data{"input": &sanitizedDBInstanceInput})
+
+	promoteDBInstanceOutput, err := r.rdssvc.PromoteReadReplica(promoteReadReplicaInput)
+	if err != nil {
+		return nil, HandleAWSError(err, r.logger)
+	}
+	r.logger.Debug("promote-db-instance-read-replica", lager.Data{"output": promoteDBInstanceOutput})
+
+	return promoteDBInstanceOutput.DBInstance, nil
+}
+
 func (r *RDSDBInstance) Restore(restoreDBInstanceInput *rds.RestoreDBInstanceFromDBSnapshotInput) error {
 	r.logger.Debug("restore-db-instance", lager.Data{"input": &restoreDBInstanceInput})
 

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -27,10 +27,11 @@ type UpdateParameters struct {
 	EnableExtensions           []string `json:"enable_extensions"`
 	DisableExtensions          []string `json:"disable_extensions"`
 	MaxAllocatedStorage        int64    `json:"max_allocated_storage"`
+	PromoteReplica             bool     `json:"promote_replica"`
 }
 
 type BindParameters struct {
-	GrantReplication	bool	`json:"grant_replication"`
+	GrantReplication bool `json:"grant_replication"`
 }
 
 func (pp *ProvisionParameters) Validate() error {


### PR DESCRIPTION
Adds the `promote_replica` parameter to the OSB Update method. When applied against a service instance that is a read replica of another instance, it will attempt to promote that instance to a standalone instance and update the main credentials for the instance to allow the broker to fully manage the instance and create bind users.

Note: Any existing data in a promoted read replica is not guaranteed to be owned by the broker's manager role and bind users may not have sufficient permission to read/write from existing tables. We will be addressing this the future.